### PR TITLE
Skip testing of fragment components

### DIFF
--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -48,28 +48,30 @@ export function initialize(application) {
      * @return {Void}
      */
     audit() {
-      axe.a11yCheck(this.$(), this.axeOptions, (results) => {
-        let violations = results.violations;
+      if (this.get('tagName') !== '') {
+        axe.a11yCheck(this.$(), this.axeOptions, (results) => {
+          let violations = results.violations;
 
-        for (let i = 0, l = violations.length; i < l; i++) {
-          let violation = violations[i];
+          for (let i = 0, l = violations.length; i < l; i++) {
+            let violation = violations[i];
 
-          Ember.Logger.error(`Violation #${i+1}`, violation);
+            Ember.Logger.error(`Violation #${i+1}`, violation);
 
-          let nodes = violation.nodes;
+            let nodes = violation.nodes;
 
-          for (let j = 0, k = nodes.length; j < k; j++) {
-            let node = nodes[i];
+            for (let j = 0, k = nodes.length; j < k; j++) {
+              let node = nodes[i];
 
-            this.$(node.target.join(','))[0].classList.add('axe-violation');
+              this.$(node.target.join(','))[0].classList.add('axe-violation');
+            }
           }
-        }
 
-        if (this.axeCallback) {
-          Ember.assert('axeCallback should be a function.', typeof this.axeCallback === 'function');
-          this.axeCallback(results);
-        }
-      });
+          if (this.axeCallback) {
+            Ember.assert('axeCallback should be a function.', typeof this.axeCallback === 'function');
+            this.axeCallback(results);
+          }
+        });
+      }
     }
   });
 


### PR DESCRIPTION
Hey, thanks for writing this library. In using it, I found I had to add this check for components that have a `tagName` of `''`; as in, they are missing a wrapper element. I’m having a hard time finding documentation on this, but components configured this way don’t have a `this.$` because there’s no element for that to point to.

It galls me to submit this PR without a test, but I couldn’t figure out how to add one! I tried adding a `{{fragment-component}}` in `tests/dummy/app/templates/application.hbs`, but it had no effect. Adding an invalid component had no effect there either, leading me to believe that template isn’t being exercised by the tests. But maybe I’m missing something. I’d gladly add a test for this with some guidance!
