### PR TITLE
Add more descriptive violation logging

### DIFF
--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -14,12 +14,35 @@
     a11yCheckCallback: function(results) {
       var violations = results.violations;
 
-      for (var i = 0, l = violations.length; i < l; i++) {
-        Ember.Logger.error('Violation #' + (i + 1), violations[i]);
-      }
+      if (violations.length) {
+        Ember.Logger.error('ACCESSIBILITY VIOLATIONS: ' + violations.length);
 
-      Ember.assert('The page should have no accessibility violations.', !violations.length);
+        for (var i = 0, l = violations.length; i < l; i++) {
+          var violation = violations[i];
+          var violationNodeString = axe.ember.nodesToString(violation.nodes);
+
+          Ember.Logger.warn(violation.impact.toUpperCase() + ': ' + violation.help);
+          Ember.Logger.info('Offending markup (' + violation.nodes.length + '): ' + violationNodeString);
+          Ember.Logger.info('Additional info: ' + violation.helpUrl);
+          Ember.Logger.info('-------------------------------------');
+        }
+      }
+      Ember.assert('The page should have no accessibility violations. Please check the developer console for more details.', !violations.length);
     },
+
+    /**
+     * Takes the violations' nodes param and converts it to
+     * a string that can be displayed with the console error.
+     * @param {Array} nodes
+     * @return {String}
+     */
+     nodesToString: function(nodes) {
+       var nodesString = nodes.map(function(node) {
+         return node.html;
+       });
+
+       return nodesString.join(', ');
+     },
 
     /**
      * Used as a callback for afterRender. Simply runs axe.a11yCheck and passes

--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -37,11 +37,9 @@
      * @return {String}
      */
      nodesToString: function(nodes) {
-       var nodesString = nodes.map(function(node) {
+       return nodes.map(function(node) {
          return node.html;
-       });
-
-       return nodesString.join(', ');
+       }).join(', ');
      },
 
     /**

--- a/tests/unit/test-body-footer-test.js
+++ b/tests/unit/test-body-footer-test.js
@@ -37,9 +37,9 @@ test('a11yCheckCallback should log any violations and throw an error', function(
 
   assert.throws(() => {
     axe.ember.a11yCheckCallback({ violations: [ {}, {} ] });
-  }, 'The page should have no accessibility violations.');
+  }, 'The page should have no accessibility violations. Please check the developer console for more details.');
 
-  assert.ok(loggerStub.calledTwice);
+  assert.equal(loggerStub.callCount, 1, 'An error is thrown when there are violations');
 });
 
 /* axe.ember.afterRender */


### PR DESCRIPTION
Howdy! 👋 

As we are about to use this add-on in a new application, the other developer and I thought it would be nice to have more descriptive logging in the console rather than sifting through the `violations` object output.

This both updates the default messages that is displayed inside the browser test runner, along with more precise console logging, rather than dumping the entire `violations` object.
### RFC

It seems the `default` environment tests hang due to differences in Ember versions. I'm not entirely sure how to go about fixing that. Not sure if it has something to do with the [WIP Ember upgrade](https://github.com/trentmwillis/ember-axe/pull/6) or what the best way to resolve it now would be.
#### New test runner messaging

<img width="1438" alt="screen shot 2016-05-12 at 8 34 10 pm" src="https://cloud.githubusercontent.com/assets/579649/15234958/4b00906c-1885-11e6-8300-8a6efcb2b2bb.png">
#### New console level information

<img width="546" alt="screen shot 2016-05-13 at 11 02 22 am" src="https://cloud.githubusercontent.com/assets/579649/15252061/3acd60f6-18fa-11e6-881f-4c9e6b46a04a.png">
